### PR TITLE
feat: support multipe sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,42 @@ const html = renderHTML({
 - `swagger`: Swagger UI configuration.
 - `kong`: Kong Spec Renderer UI configuration.
 
+### Multiple sources
+
+You can render multiple OpenAPI documents with the `scalar` and `swagger` renderers. When configured, the top-level `spec` option is ignored by the corresponding renderer.
+
+```js
+// https://scalar.com/products/api-references/configuration#multiple-configurations-with-sources-advanced
+renderHTML({
+  renderer: "scalar",
+  scalar: {
+    sources: [
+      { url: "/openapi.json", title: "My API" },
+      {
+        url: "/api/auth/open-api/generate-schema",
+        title: "Auth",
+        default: true,
+      },
+    ],
+  },
+});
+
+// https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/#:~:text=An%20array%20of%20API%20definition%20objects
+renderHTML({
+  renderer: "swagger",
+  swagger: {
+    urls: [
+      { url: "/openapi.json", name: "My API" },
+      {
+        url: "/api/auth/open-api/generate-schema",
+        name: "Auth",
+        default: true,
+      },
+    ],
+  },
+});
+```
+
 ## Development
 
 - Clone this repository

--- a/playground/index.mjs
+++ b/playground/index.mjs
@@ -2,10 +2,35 @@ import { serve } from "srvx";
 import { renderResponse } from "openapi-renderer";
 
 const DEMO_SPEC = "https://petstore.swagger.io/v2/swagger.json";
+const DEMO_SPEC_V3 = "https://petstore3.swagger.io/api/v3/openapi.json";
 
 serve({
   fetch(req) {
     const { searchParams: query } = new URL(req.url);
+
+    if (query.get("multi") === "scalar") {
+      return renderResponse(req, {
+        renderer: "scalar",
+        scalar: {
+          sources: [
+            { url: DEMO_SPEC, title: "Petstore v2" },
+            { url: DEMO_SPEC_V3, title: "Petstore v3", default: true },
+          ],
+        },
+      });
+    }
+
+    if (query.get("multi") === "swagger") {
+      return renderResponse(req, {
+        renderer: "swagger",
+        swagger: {
+          urls: [
+            { url: DEMO_SPEC, name: "Petstore v2" },
+            { url: DEMO_SPEC_V3, name: "Petstore v3", default: true },
+          ],
+        },
+      });
+    }
 
     if (query.get("renderer")) {
       return renderResponse(req, {
@@ -30,6 +55,12 @@ serve({
                 </li>
                 <li>
                   <a href="/?renderer=kong&spec=${DEMO_SPEC}">Kong UI</a>
+                </li>
+                <li>
+                  <a href="/?multi=scalar">Scalar UI (multiple sources)</a>
+                </li>
+                <li>
+                  <a href="/?multi=swagger">Swagger UI (multiple sources)</a>
                 </li>
             </p>
           </body>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,8 @@
-export type { RenderHTMLOptions, RenderResponseOptions } from "./types.ts";
+export type {
+  RenderHTMLOptions,
+  RenderResponseOptions,
+  ScalarSource,
+  SwaggerUrl,
+} from "./types.ts";
 
 export { renderHTML, renderResponse } from "./render.ts";

--- a/src/renderers/scalar.ts
+++ b/src/renderers/scalar.ts
@@ -8,10 +8,16 @@ export default function render(opts: RenderHTMLOptions): string {
     opts.scalar?.cdnURL ||
     "https://cdn.jsdelivr.net/npm/@scalar/api-reference@^1";
 
-  const scalarConfig: ScalarConfig = {
-    ...opts.scalar,
-    url: opts.spec,
-  };
+  const { cdnURL: _, ...userConfig } = opts.scalar || {};
+
+  // With `sources`, the top-level `spec` option is ignored
+  // https://scalar.com/products/api-references/configuration#multiple-configurations-with-sources-advanced
+  const scalarConfig: ScalarConfig = userConfig.sources?.length
+    ? userConfig
+    : {
+        ...userConfig,
+        url: opts.spec,
+      };
 
   return /* html */ `<!doctype html>
     <html lang="en">

--- a/src/renderers/swagger.ts
+++ b/src/renderers/swagger.ts
@@ -6,6 +6,22 @@ export default function render(opts: RenderHTMLOptions) {
   const CDN_URL =
     opts.swagger?.cdnURL || "https://cdn.jsdelivr.net/npm/swagger-ui-dist@^5";
 
+  // With `urls`, Swagger UI shows a document selector dropdown and the
+  // top-level `spec` option is ignored
+  const specConfig: Record<string, any> = opts.swagger?.urls?.length
+    ? {
+        urls: opts.swagger.urls.map(({ url, name }) => ({
+          url,
+          name: name || url,
+        })),
+      }
+    : { url: opts.spec };
+
+  const primary = opts.swagger?.urls?.find((entry) => entry.default);
+  if (primary) {
+    specConfig["urls.primaryName"] = primary.name || primary.url;
+  }
+
   return /* html */ `<!doctype html>
     <html lang="en">
       <head>
@@ -26,7 +42,7 @@ export default function render(opts: RenderHTMLOptions) {
         <script>
           window.onload = () => {
             window.ui = SwaggerUIBundle({
-              url: ${JSON.stringify(opts.spec)},
+              ...${JSON.stringify(specConfig)},
               dom_id: "#swagger-ui",
               presets: [
                 SwaggerUIBundle.presets.apis,

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,9 @@ export interface RenderHTMLOptions {
   /**
    * The route to the OpenAPI specification to render.
    *
+   * Ignored by the corresponding renderer when `scalar.sources` or
+   * `swagger.urls` is configured.
+   *
    * @default "./openapi.json"
    */
   spec?: string;
@@ -40,6 +43,15 @@ export interface RenderHTMLOptions {
    */
   scalar?: Partial<ScalarConfig> & {
     cdnURL?: string;
+
+    /**
+     * Multiple OpenAPI documents to render.
+     *
+     * When set, the top-level `spec` option is ignored.
+     *
+     * @see https://scalar.com/products/api-references/configuration#multiple-configurations-with-sources-advanced
+     */
+    sources?: ScalarSource[];
   };
 
   /**
@@ -47,6 +59,13 @@ export interface RenderHTMLOptions {
    */
   swagger?: {
     cdnURL?: string;
+
+    /**
+     * Multiple OpenAPI documents to render, selectable via a dropdown.
+     *
+     * When set, the top-level `spec` option is ignored.
+     */
+    urls?: SwaggerUrl[];
   };
 
   /**
@@ -55,6 +74,40 @@ export interface RenderHTMLOptions {
   kong?: Partial<KongConfig> & {
     cdnURL?: string;
   };
+}
+
+/**
+ * An OpenAPI document source for the Scalar renderer.
+ */
+export interface ScalarSource {
+  /** URL to an OpenAPI/Swagger document */
+  url?: string;
+
+  /** Directly embed the OpenAPI document (JSON string or object) */
+  content?: string | Record<string, any>;
+
+  /** Title of the OpenAPI document */
+  title?: string;
+
+  /** Slug used in the URL */
+  slug?: string;
+
+  /** Whether this is the default document */
+  default?: boolean;
+}
+
+/**
+ * An OpenAPI document source for the Swagger UI renderer.
+ */
+export interface SwaggerUrl {
+  /** URL to an OpenAPI/Swagger document */
+  url: string;
+
+  /** Display name in the document selector dropdown */
+  name?: string;
+
+  /** Whether this is the default document (maps to `urls.primaryName`) */
+  default?: boolean;
 }
 
 export interface RenderResponseOptions extends RenderHTMLOptions {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -11,3 +11,49 @@ describe("renderHTML", () => {
     });
   }
 });
+
+describe("multiple sources", () => {
+  it("renders scalar with sources", () => {
+    const result = renderHTML({
+      renderer: "scalar",
+      scalar: {
+        sources: [
+          { url: "./a.json" },
+          { url: "./b.json", title: "Auth", default: true },
+        ],
+      },
+    });
+    expect(result).toContain('"sources"');
+    expect(result).toContain('"url":"./a.json"');
+    expect(result).toContain('"url":"./b.json"');
+    expect(result).toContain('"default":true');
+    expect(result).not.toContain("./openapi.json");
+  });
+
+  it("renders scalar with embedded content source", () => {
+    const result = renderHTML({
+      renderer: "scalar",
+      scalar: {
+        sources: [{ content: { openapi: "3.1.1" } }],
+      },
+    });
+    expect(result).toContain('"content":{"openapi":"3.1.1"}');
+  });
+
+  it("renders swagger with urls", () => {
+    const result = renderHTML({
+      renderer: "swagger",
+      swagger: {
+        urls: [
+          { url: "./a.json" },
+          { url: "./b.json", name: "Auth", default: true },
+        ],
+      },
+    });
+    expect(result).toContain('"urls"');
+    expect(result).toContain('{"url":"./a.json","name":"./a.json"}');
+    expect(result).toContain('{"url":"./b.json","name":"Auth"}');
+    expect(result).toContain('"urls.primaryName":"Auth"');
+    expect(result).not.toContain("./openapi.json");
+  });
+});


### PR DESCRIPTION
close #27

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for rendering multiple OpenAPI documents with Scalar and Swagger.
  - Scalar supports multiple URL or embedded content sources, with a default selection.
  - Swagger supports multiple selectable document URLs with a default entry.
  - Added playground examples demonstrating multi-source rendering.

- **Documentation**
  - Documented multi-source configuration and clarified how it interacts with the top-level specification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->