### PR TITLE
fix: escape renderer metadata

### DIFF
--- a/src/renderers/kong.ts
+++ b/src/renderers/kong.ts
@@ -1,5 +1,6 @@
 import type { SpecRendererNitroConfig as KongConfig } from "@kong/spec-renderer";
 import type { RenderHTMLOptions } from "../types.ts";
+import { escapeHTML } from "../utils.ts";
 
 // https://github.com/Kong/spec-renderer
 
@@ -22,8 +23,8 @@ export default function render(opts: RenderHTMLOptions): string {
       <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta name="description" content="${opts.meta?.description || ""}" />
-        <title>${opts?.meta?.title || ""}</title>
+        <meta name="description" content="${escapeHTML(opts.meta?.description || "")}" />
+        <title>${escapeHTML(opts.meta?.title || "")}</title>
         <link rel="stylesheet" href="${CDN_URL}/dist/spec-renderer.css" />
         <link rel="preconnect" href="https://fonts.googleapis.com">
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/src/renderers/scalar.ts
+++ b/src/renderers/scalar.ts
@@ -1,5 +1,6 @@
 import type { ApiReferenceConfiguration as ScalarConfig } from "@scalar/api-reference";
 import type { RenderHTMLOptions } from "../types.ts";
+import { escapeHTML } from "../utils.ts";
 
 // https://github.com/scalar/scalar
 
@@ -18,8 +19,8 @@ export default function render(opts: RenderHTMLOptions): string {
       <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta name="description" content="${opts.meta?.description}" />
-        <title>${opts.meta?.title}</title>
+        <meta name="description" content="${escapeHTML(opts.meta?.description || "")}" />
+        <title>${escapeHTML(opts.meta?.title || "")}</title>
         <style>${opts.styles}</style>
       </head>
       <body>

--- a/src/renderers/swagger.ts
+++ b/src/renderers/swagger.ts
@@ -1,4 +1,5 @@
 import type { RenderHTMLOptions } from "../types.ts";
+import { escapeHTML } from "../utils.ts";
 
 // https://github.com/swagger-api/swagger-ui
 
@@ -11,8 +12,8 @@ export default function render(opts: RenderHTMLOptions) {
       <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta name="description" content="${opts.meta?.description}" />
-        <title>${opts.meta?.title}</title>
+        <meta name="description" content="${escapeHTML(opts.meta?.description || "")}" />
+        <title>${escapeHTML(opts.meta?.title || "")}</title>
         <link rel="stylesheet" href="${CDN_URL}/swagger-ui.css" />
         <style>${opts.styles}</style>
       </head>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,21 @@
+export function escapeHTML(value: string): string {
+  return value.replaceAll(/[&<>"']/g, (character) => {
+    switch (character) {
+      case "&": {
+        return "&amp;";
+      }
+      case "<": {
+        return "&lt;";
+      }
+      case ">": {
+        return "&gt;";
+      }
+      case '"': {
+        return "&quot;";
+      }
+      default: {
+        return "&#39;";
+      }
+    }
+  });
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -9,5 +9,24 @@ describe("renderHTML", () => {
       const result = renderHTML({ renderer: name });
       expect(result).toContain("./openapi.json");
     });
+
+    it(`escapes metadata with ${name}`, () => {
+      const result = renderHTML({
+        renderer: name,
+        meta: {
+          title: `API </title><script>alert("title")</script>`,
+          description: `Docs & more"><script>alert('description')</script>`,
+        },
+      });
+
+      expect(result).toContain(
+        `<title>API &lt;/title&gt;&lt;script&gt;alert(&quot;title&quot;)&lt;/script&gt;</title>`,
+      );
+      expect(result).toContain(
+        `content="Docs &amp; more&quot;&gt;&lt;script&gt;alert(&#39;description&#39;)&lt;/script&gt;"`,
+      );
+      expect(result).not.toContain(`<script>alert("title")</script>`);
+      expect(result).not.toContain(`<script>alert('description')</script>`);
+    });
   }
 });


### PR DESCRIPTION
## What changed

- Escape HTML-sensitive characters in renderer metadata before inserting it into the document head.
- Apply the same handling to the Kong, Scalar, and Swagger renderers.
- Add regression coverage for title-element and description-attribute injection attempts.

## Why

Metadata was interpolated directly into `<title>` and `<meta name=description>`, so values containing markup could break out of those contexts and inject HTML. The shared escaping helper preserves the displayed text while keeping the generated document structure intact. Explicit custom CSS remains raw by design.

Fixes #26.

## Checks

- `prettier -c` on all changed files
- `eslint` on all changed files
- `tsc --noEmit --skipLibCheck`
- `vitest run --coverage=false` (6 tests passed)
- `obuild`