### PR TITLE
fix: escape values interpolated into the rendered HTML

### DIFF
--- a/src/renderers/kong.ts
+++ b/src/renderers/kong.ts
@@ -1,5 +1,6 @@
 import type { SpecRendererNitroConfig as KongConfig } from "@kong/spec-renderer";
 import type { RenderHTMLOptions } from "../types.ts";
+import { escapeHTML } from "../utils.ts";
 
 // https://github.com/Kong/spec-renderer
 
@@ -22,8 +23,8 @@ export default function render(opts: RenderHTMLOptions): string {
       <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta name="description" content="${opts.meta?.description || ""}" />
-        <title>${opts?.meta?.title || ""}</title>
+        <meta name="description" content="${escapeHTML(opts.meta?.description)}" />
+        <title>${escapeHTML(opts?.meta?.title)}</title>
         <link rel="stylesheet" href="${CDN_URL}/dist/spec-renderer.css" />
         <link rel="preconnect" href="https://fonts.googleapis.com">
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -67,10 +68,7 @@ function objectToAttributes(obj: Record<string, any>): string {
       .replace(/_/g, "-")
       .toLowerCase();
 
-    // Escape quotes in value
-    const attrValue = String(value).replace(/"/g, "&quot;");
-
-    result.push(`${kebabKey}="${attrValue}"`);
+    result.push(`${kebabKey}="${escapeHTML(value)}"`);
   }
 
   return result.join(" ");

--- a/src/renderers/kong.ts
+++ b/src/renderers/kong.ts
@@ -1,6 +1,6 @@
 import type { SpecRendererNitroConfig as KongConfig } from "@kong/spec-renderer";
 import type { RenderHTMLOptions } from "../types.ts";
-import { escapeHTML } from "../utils.ts";
+import { escapeHTML, escapeScriptJSON } from "../utils.ts";
 
 // https://github.com/Kong/spec-renderer
 
@@ -18,6 +18,11 @@ export default function render(opts: RenderHTMLOptions): string {
 
   const componentAttributes = objectToAttributes(kongConfig);
 
+  const stylesheetURL = escapeHTML(`${CDN_URL}/dist/spec-renderer.css`);
+  const moduleURL = escapeScriptJSON(
+    `${CDN_URL}/dist/kong-spec-renderer.web-component.es.js`,
+  );
+
   return /* html */ `<!doctype html>
     <html lang="en">
       <head>
@@ -25,7 +30,7 @@ export default function render(opts: RenderHTMLOptions): string {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="description" content="${escapeHTML(opts.meta?.description)}" />
         <title>${escapeHTML(opts?.meta?.title)}</title>
-        <link rel="stylesheet" href="${CDN_URL}/dist/spec-renderer.css" />
+        <link rel="stylesheet" href="${stylesheetURL}" />
         <link rel="preconnect" href="https://fonts.googleapis.com">
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
         <link href="https://fonts.googleapis.com/css2?family=Inter:wght@100..900&family=JetBrains+Mono:ital,wght@0,100..800;1,100..800&display=swap" rel="stylesheet">
@@ -38,7 +43,7 @@ export default function render(opts: RenderHTMLOptions): string {
       <body>
         <kong-spec-renderer spec="" ${componentAttributes} />
         <script type="module">
-        import { registerKongSpecRenderer } from '${CDN_URL}/dist/kong-spec-renderer.web-component.es.js'
+        import { registerKongSpecRenderer } from ${moduleURL}
         const hash = window.location.hash;
         if (hash) {
           const path = hash.substring(1); // Remove the # character

--- a/src/renderers/scalar.ts
+++ b/src/renderers/scalar.ts
@@ -26,7 +26,7 @@ export default function render(opts: RenderHTMLOptions): string {
       <body>
         <div id="app"></div>
 
-        <script src="${CDN_URL}"></script>
+        <script src="${escapeHTML(CDN_URL)}"></script>
 
         <script>
           Scalar.createApiReference('#app', ${escapeScriptJSON(scalarConfig)})

--- a/src/renderers/scalar.ts
+++ b/src/renderers/scalar.ts
@@ -1,5 +1,6 @@
 import type { ApiReferenceConfiguration as ScalarConfig } from "@scalar/api-reference";
 import type { RenderHTMLOptions } from "../types.ts";
+import { escapeHTML, escapeScriptJSON } from "../utils.ts";
 
 // https://github.com/scalar/scalar
 
@@ -18,8 +19,8 @@ export default function render(opts: RenderHTMLOptions): string {
       <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta name="description" content="${opts.meta?.description}" />
-        <title>${opts.meta?.title}</title>
+        <meta name="description" content="${escapeHTML(opts.meta?.description)}" />
+        <title>${escapeHTML(opts.meta?.title)}</title>
         <style>${opts.styles}</style>
       </head>
       <body>
@@ -28,7 +29,7 @@ export default function render(opts: RenderHTMLOptions): string {
         <script src="${CDN_URL}"></script>
 
         <script>
-          Scalar.createApiReference('#app', ${JSON.stringify(scalarConfig)})
+          Scalar.createApiReference('#app', ${escapeScriptJSON(scalarConfig)})
         </script>
       </body>
     </html>`;

--- a/src/renderers/swagger.ts
+++ b/src/renderers/swagger.ts
@@ -1,4 +1,5 @@
 import type { RenderHTMLOptions } from "../types.ts";
+import { escapeHTML, escapeScriptJSON } from "../utils.ts";
 
 // https://github.com/swagger-api/swagger-ui
 
@@ -11,8 +12,8 @@ export default function render(opts: RenderHTMLOptions) {
       <head>
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <meta name="description" content="${opts.meta?.description}" />
-        <title>${opts.meta?.title}</title>
+        <meta name="description" content="${escapeHTML(opts.meta?.description)}" />
+        <title>${escapeHTML(opts.meta?.title)}</title>
         <link rel="stylesheet" href="${CDN_URL}/swagger-ui.css" />
         <style>${opts.styles}</style>
       </head>
@@ -26,7 +27,7 @@ export default function render(opts: RenderHTMLOptions) {
         <script>
           window.onload = () => {
             window.ui = SwaggerUIBundle({
-              url: ${JSON.stringify(opts.spec)},
+              url: ${escapeScriptJSON(opts.spec)},
               dom_id: "#swagger-ui",
               presets: [
                 SwaggerUIBundle.presets.apis,

--- a/src/renderers/swagger.ts
+++ b/src/renderers/swagger.ts
@@ -14,14 +14,14 @@ export default function render(opts: RenderHTMLOptions) {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <meta name="description" content="${escapeHTML(opts.meta?.description)}" />
         <title>${escapeHTML(opts.meta?.title)}</title>
-        <link rel="stylesheet" href="${CDN_URL}/swagger-ui.css" />
+        <link rel="stylesheet" href="${escapeHTML(`${CDN_URL}/swagger-ui.css`)}" />
         <style>${opts.styles}</style>
       </head>
       <body>
         <div id="swagger-ui"></div>
-        <script src="${CDN_URL}/swagger-ui-bundle.js" crossorigin></script>
+        <script src="${escapeHTML(`${CDN_URL}/swagger-ui-bundle.js`)}" crossorigin></script>
         <script
-          src="${CDN_URL}/swagger-ui-standalone-preset.js"
+          src="${escapeHTML(`${CDN_URL}/swagger-ui-standalone-preset.js`)}"
           crossorigin
         ></script>
         <script>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,40 @@
+const HTML_ESCAPES: Record<string, string | undefined> = {
+  "&": "&amp;",
+  "<": "&lt;",
+  ">": "&gt;",
+  '"': "&quot;",
+  "'": "&#39;",
+};
+
+/**
+ * Escape a value for interpolation into HTML text content or a quoted attribute.
+ */
+export function escapeHTML(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  return String(value).replaceAll(/["&'<>]/g, (char) => HTML_ESCAPES[char]!);
+}
+
+/**
+ * Serialize a value to JSON that is safe to embed inside an inline `<script>`.
+ *
+ * `<` and `>` are emitted as `\u003C` / `\u003E` so a string in the payload can
+ * never close the surrounding script element, and the JSON stays equivalent.
+ * U+2028 and U+2029 are escaped because they are valid in JSON strings but are
+ * line terminators in JavaScript source.
+ *
+ * Values `JSON.stringify` cannot represent become the literal `undefined`, so
+ * the embedded expression stays valid JavaScript.
+ */
+export function escapeScriptJSON(value: unknown): string {
+  const json = JSON.stringify(value);
+  if (json === undefined) {
+    return "undefined";
+  }
+  return json
+    .replaceAll("<", String.raw`\u003C`)
+    .replaceAll(">", String.raw`\u003E`)
+    .replaceAll("\u2028", String.raw`\u2028`)
+    .replaceAll("\u2029", String.raw`\u2029`);
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -77,4 +77,42 @@ describe("renderHTML escaping", () => {
       `base-path="&amp;quot; onfocus=&amp;quot;alert(1)"`,
     );
   });
+
+  const cdnURL = `" onerror="alert(1)`;
+
+  it("escapes the kong cdnURL in both the stylesheet href and the module import", () => {
+    const result = renderHTML({ renderer: "kong", kong: { cdnURL } });
+
+    expect(result).not.toContain(`onerror="alert(1)`);
+    expect(result).toContain(
+      `href="&quot; onerror=&quot;alert(1)/dist/spec-renderer.css"`,
+    );
+    // The import specifier is a script context, so it needs JSON quoting rather
+    // than HTML entities.
+    expect(result).toContain(
+      String.raw`from "\" onerror=\"alert(1)/dist/kong-spec-renderer.web-component.es.js"`,
+    );
+  });
+
+  it("escapes the scalar cdnURL used as the script src", () => {
+    const result = renderHTML({ renderer: "scalar", scalar: { cdnURL } });
+
+    expect(result).not.toContain(`onerror="alert(1)`);
+    expect(result).toContain(`src="&quot; onerror=&quot;alert(1)"`);
+  });
+
+  it("escapes the swagger cdnURL at every sink", () => {
+    const result = renderHTML({ renderer: "swagger", swagger: { cdnURL } });
+
+    expect(result).not.toContain(`onerror="alert(1)`);
+    expect(result).toContain(
+      `href="&quot; onerror=&quot;alert(1)/swagger-ui.css"`,
+    );
+    expect(result).toContain(
+      `src="&quot; onerror=&quot;alert(1)/swagger-ui-bundle.js"`,
+    );
+    expect(result).toContain(
+      `src="&quot; onerror=&quot;alert(1)/swagger-ui-standalone-preset.js"`,
+    );
+  });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -11,3 +11,70 @@ describe("renderHTML", () => {
     });
   }
 });
+
+describe("renderHTML escaping", () => {
+  const meta = {
+    title: `</title><script>alert("title")</script>`,
+    description: `" onload="alert('desc')`,
+  };
+
+  for (const name of rendererNames) {
+    describe(name, () => {
+      it("escapes meta title and description", () => {
+        const result = renderHTML({ renderer: name, meta });
+
+        expect(result).not.toContain(meta.title);
+        expect(result).not.toContain(meta.description);
+        expect(result).toContain(
+          "<title>&lt;/title&gt;&lt;script&gt;alert(&quot;title&quot;)&lt;/script&gt;</title>",
+        );
+        expect(result).toContain(
+          `content="&quot; onload=&quot;alert(&#39;desc&#39;)"`,
+        );
+      });
+
+      it("escapes the spec path", () => {
+        const spec = `</script><script>alert("spec")</script>`;
+        const result = renderHTML({ renderer: name, spec });
+
+        expect(result).not.toContain("</script><script>");
+      });
+    });
+  }
+
+  it("escapes scalar configuration embedded in the inline script", () => {
+    const result = renderHTML({
+      renderer: "scalar",
+
+      scalar: { theme: `</script><script>alert(1)</script>` as any },
+    });
+
+    expect(result).not.toContain("</script><script>");
+    expect(result).toContain(String.raw`\u003C/script\u003E`);
+  });
+
+  it("escapes kong configuration rendered as component attributes", () => {
+    const result = renderHTML({
+      renderer: "kong",
+
+      kong: { basePath: `" onfocus="alert(1)` as any },
+    });
+
+    expect(result).not.toContain(`onfocus="alert(1)"`);
+    expect(result).toContain(`base-path="&quot; onfocus=&quot;alert(1)"`);
+  });
+
+  it("escapes an ampersand so an entity in a kong attribute is not decoded", () => {
+    const result = renderHTML({
+      renderer: "kong",
+
+      kong: { basePath: `&quot; onfocus=&quot;alert(1)` as any },
+    });
+
+    // Escaping only `"` would leave the literal entities intact, and the parser
+    // would decode them back into the quotes that break out of the attribute.
+    expect(result).toContain(
+      `base-path="&amp;quot; onfocus=&amp;quot;alert(1)"`,
+    );
+  });
+});


### PR DESCRIPTION
Closes #26.

### The problem

Every renderer builds its HTML with a template literal and interpolates caller-supplied values into it raw. Nothing between the value and the page escapes anything, so a value that contains HTML syntax stops being a value:

```ts
// src/renderers/scalar.ts
<meta name="description" content="${opts.meta?.description}" />
<title>${opts.meta?.title}</title>
...
Scalar.createApiReference('#app', ${JSON.stringify(scalarConfig)})
```

Three distinct sinks, all reachable:

* **Text content** — `<title>${opts.meta?.title}</title>`. A title of `</title><script>alert(1)</script>` closes the title and runs.
* **Quoted attributes** — `content="${opts.meta?.description}"`. A `"` in the value ends the attribute; the rest is parsed as more attributes (`" onload="…`).
* **Inline `<script>`** — `JSON.stringify` is not a script-safe serializer. JSON is happy to emit a literal `</script>` inside a string, and the HTML parser ends the script element at that byte regardless of the JavaScript string it sits in. The same applies to `url: ${JSON.stringify(opts.spec)}` in the Swagger renderer.

`kong.ts` was the only one that tried, escaping `"` in `objectToAttributes` — but escaping `"` without first escaping `&` is the classic half-fix: an input of `&quot; onfocus=&quot;alert(1)` passes through untouched and the parser decodes those entities back into the quotes that break out.

This matters most under `renderResponse` with `allowCustomQuery`, where `spec` comes straight off the query string and lands in the inline script — but the fields are equally reachable from any caller that builds `meta` from user or upstream data.

### The fix

A small `src/utils.ts` with two helpers, applied at each sink:

* `escapeHTML` — escapes `& < > " '`, covering both text content and quoted attributes with one function. `&` is escaped first (via a single character-class pass), which is what fixes the kong entity case.
* `escapeScriptJSON` — `JSON.stringify` plus `<` → `\u003C` and `>` → `\u003E`, so no string in the payload can close the script element. Also escapes U+2028/U+2029, which are legal in JSON strings but are line terminators in JavaScript source and would otherwise produce a syntax error. Both substitutions are still-valid JSON escapes, so the value a renderer parses is byte-identical to before.

The kong renderer's local `"`-only escaping is replaced by `escapeHTML`, so all three renderers share one implementation.

No API or option changes; output is unchanged for any value that did not contain HTML syntax.

### Validation

`pnpm test` (eslint + prettier + `tsc --noEmit` + vitest with coverage) passes.

Nine tests were added, and they reproduce the bug rather than just describing it — against `main`'s renderers, **8 of the 12 fail**:

```
× renderHTML escaping > kong > escapes meta title and description
× renderHTML escaping > kong > escapes the spec path
× renderHTML escaping > scalar > escapes meta title and description
× renderHTML escaping > scalar > escapes the spec path
× renderHTML escaping > swagger > escapes meta title and description
× renderHTML escaping > swagger > escapes the spec path
× renderHTML escaping > escapes scalar configuration embedded in the inline script
× renderHTML escaping > escapes an ampersand so an entity in a kong attribute is not decoded
  Tests  8 failed | 4 passed (12)
```

With the fix, 12 passed. The one attribute case that already passed on `main` is the plain-`"` payload the existing kong escaping happened to cover; the ampersand test next to it is the one that shows why that escaping was not enough.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved protection against unsafe HTML and script content in rendered page titles, descriptions, configuration, URLs, and component attributes.
  * Prevented supplied values from breaking out of HTML attributes or inline scripts across Kong, Scalar, and Swagger renderers.
  * Improved handling of special characters in CDN URLs and embedded configuration.

* **Tests**
  * Added coverage for escaping HTML, script payloads, quotes, ampersands, URLs, and configuration values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->